### PR TITLE
[bug-861360] Displaying the signed in user data from the UI

### DIFF
--- a/app/dev/public/index.html
+++ b/app/dev/public/index.html
@@ -15,16 +15,10 @@
           personaSSO = navigator.personaSSO;
       document.title = "App " + appNumber;
       $('h1').html(document.title);
-
-      personaSSO.init($("#SSO")[0], function(){console.log("onready");});
+      personaSSO.init($("#SSO")[0]);
       personaSSO.id.watch({
-        loggedInUser: null, // we don't think anyone's authenticated because we don't hold state in this HTML-only version
         onlogin: function(topic, data){
-          if (data.exists) {
-            console.log("we have a webmaker");
-          } else {
-            personaSSO.ui.newMaker(data.loggedInUser, $('#webmaker-nav'));
-          }
+          personaSSO.ui.checkMaker(data, $('#webmaker-nav'));
         },
         onlogout: function(){
           personaSSO.ui.loggedOut();

--- a/app/http/views/ajax/forms/new_user.ejs
+++ b/app/http/views/ajax/forms/new_user.ejs
@@ -1,12 +1,8 @@
 <form id="sso_create" action="<%= process.env.AUDIENCE %>/user" method="POST">
   <p><strong>Welcome new Webmaker</strong> - tell us a little bit about you so we can provide a personal experience.</p>
   <div class="row">
-    <label for="nick">Display name</label>
-    <input type="text" name="nick" id="nick" required />
-  </div>
-  <div class="row">
-    <label for="subdomain">Subdomain</label>
-    <input type="text" name="subdomain" id="subdomain" required />
+    <label for="name">Display name</label>
+    <input type="text" name="name" id="name" required />
   </div>
   <div class="row">
     <input type="checkbox" name="terms" id="terms" class="inline" required />

--- a/app/http/views/js/sso.ejs
+++ b/app/http/views/js/sso.ejs
@@ -1,14 +1,35 @@
 navigator.personaSSO = {
   id: {
     watch: function(opts){
-      console.log(opts, "navigator.personaSSO options");
-      navigator.personaSSO.loggedInUser = opts.loggedInUser;
       navigator.personaSSO.handlers.onlogin = opts.onlogin;
       navigator.personaSSO.handlers.onlogout = opts.onlogout;
     }
   },
   handlers: {},
   ui: {
+    displayLogin: function(userName) {
+      $("#identity").text(userName);
+    },
+    checkMaker: function(userData, elementAnchor) {
+      $.ajax({
+        type: "GET",
+        url: "<%= process.env.AUDIENCE %>/user/" + userData.loggedInUser + "/",
+        dataType: "json",
+        success: function(resp) {
+            navigator.personaSSO.ui.existingMaker(resp.user.name);
+        },
+        error: function(resp) {
+          if (resp.status === 400) {
+            // we're expecting this error for a new maker
+            navigator.personaSSO.ui.newMaker(userData.loggedInUser, $('#webmaker-nav'));
+            return false;
+          }
+          // TODO - handle errors - at this point it's a new error!
+          console.log(resp, 'failure');
+          return false;
+        }
+      });
+    },
     newMaker: function(userID, formAnchor) {
       /**
        * load in HTML include containing the HTML form
@@ -29,11 +50,10 @@ navigator.personaSSO = {
             data: {
               "_id": userID,
               "email": userID,
-              "displayName": $('#nick').val(),
-              "subdomain": $('#subdomain').val()
+              "name": $('#name').val()
             },
             success: function(resp) {
-              navigator.personaSSO.ui.existingMaker(userID, resp.user.displayName);
+              navigator.personaSSO.ui.existingMaker(resp.user.name);
               form_frag.css({"height": 0});
               form_frag.remove();
             },
@@ -47,29 +67,26 @@ navigator.personaSSO = {
         });
       });
     },
-    existingMaker: function(userID, displayName) {
+    existingMaker: function(displayName) {
       /**
        * API call to the getUserData API
        * display logged in user data in the UI (where to be defined)
        */
-      // TODO - code for when we're not passed a displayName
-      $("#identity").text(displayName);
+      navigator.personaSSO.ui.displayLogin(displayName);
     },
     loggedOut: function() {
       /**
        * remove logged in user data from the UI
        * remove any listeners we have attached
        */
-      $("#identity").text('');
+      navigator.personaSSO.ui.displayLogin('');
     }
   },
-  init: function(element, onready){
+  init: function(element){
     element.src = "<%= process.env.AUDIENCE %>/signin?" + encodeURIComponent(window.location.protocol + "//" + window.location.host);
 
     var handlers = {
-      "onready": onready,
       "onlogout": function(){
-        navigator.personaSSO.id.loggedInUser = null;
         navigator.personaSSO.id.handlers.onlogout();
       },
       "onlogin": function(data){
@@ -88,15 +105,12 @@ navigator.personaSSO = {
       try {
 
         var jsonData = JSON.parse(e.data);
-        console.log(jsonData, 'sso.js - JSON.parse');
         
         try {
           var handle = navigator.personaSSO.handlers[jsonData.topic];
-          console.log(handle, 'sso.js - handle');
           
           if (typeof(handle) == 'function'){
-            console.log(jsonData.data);
-            handle(jsonData.topic, jsonData.data);
+            handle(jsonData.topic, jsonData.data || {});
           }
         }
         catch(err){

--- a/app/http/views/site/signin.ejs
+++ b/app/http/views/site/signin.ejs
@@ -8,6 +8,10 @@
   <script type="text/javascript">
     var currentUser = "<%= typeof(user) === 'string' ? user : ''%>";
 
+    function emit(topic, data){
+        parent.postMessage(JSON.stringify({"topic": topic, "data": data}), origin);
+      }
+
     function displaySignin(){
       $("#signout").hide();
       $("#signin").show();
@@ -24,18 +28,14 @@
     var allowedDomains = "<%= process.env.ALLOWED_DOMAINS %>".split(' ');
 
     if ( $.inArray(origin, allowedDomains) != -1 ) {
-      function emit(topic, data){
-        parent.postMessage(JSON.stringify({"topic": topic, "data": data}), origin);
-      }
 
       $(function(){
         $('#signin').click(function(){navigator.id.request(); return false;});
         $('#signout').click(function(){navigator.id.logout(); return false;});
         
-        emit('onready');
-
         if (currentUser != ''){
           displaySignout();
+          emit("onlogin", {"loggedInUser": currentUser });
         }
         else{
           displaySignin();

--- a/app/models/user/user.js
+++ b/app/models/user/user.js
@@ -1,12 +1,12 @@
 var mongoose = require('../../../lib/mongoose.js'),
 mongoose_validator = require('mongoose-validator');
 
-// Custom validation  
+// Custom validation
 mongoose_validator.extend( 'isDomain', function () {
   var str = this.str;
 
-  return ( "string" === typeof( str ) && 
-    ( str.length <= 20 && str.length >= 1 ) && 
+  return ( "string" === typeof( str ) &&
+    ( str.length <= 20 && str.length >= 1 ) &&
     str.search(/^[a-zA-Z0-9\-\_]+$/) !== -1
   );
 }, "Invalid name.  All names must be between 1-20 characters, and only include \"-\", \"_\" and alphanumeric characters");


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=861360

This ensures that we show the user displayname/subdomain for our users once they are signed in - something we didn't have for all use cases before.

This gives us:
- logged in users returning
- logged in users who already have a webmaker account on a secondary page
- users without an existing subdomain/displayName
