### PR TITLE
bug883422 - Update webmaker-loginapi to v(v0.1.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "newrelic": "0.9.20",
     "node-statsd": "0.0.7",
     "winston": "0.7.1",
-    "webmaker-loginapi": "0.1.4"
+    "webmaker-loginapi": "0.1.6"
   },
   "devDependencies": {
     "grunt": "0.4.1",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=883422
