### PR TITLE
changed username lookup to explicitly inside the sign up iframe

### DIFF
--- a/app/http/views/js/sso-ux.js
+++ b/app/http/views/js/sso-ux.js
@@ -95,7 +95,7 @@
             dataType: "json",
             data: {
               "email": loggedInUser,
-              "username": $( "#username" ).val()
+              "username": $formContainer.find( "#username" ).val()
             },
             success: function(resp) {
               ui.existingMaker({


### PR DESCRIPTION
testing STR
- ensure cleared cache and cookies
- run goggles/login/webmaker localhost
- visit goggles localhost page, add localhost goggles bookmark button to bookmark bar, sign in, delete account, sign out.
- visit random non-webmaker website
- run goggles from bookmarklet
- click publish button
- sign in, fill in username, click "create" button.

**old code:** you should get an error about a missing username because the input#username element is searched for on the parent page, rather than the iframe the publish dialog is running in. (this is currently happening for goggles.mofostaging and goggles.webmaker bookmarklets)

**this patch:** things should work properly, with your username being accepted, and you getting logged in as said user.
