### PR TITLE
Travis for node 0.12 and make it faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,9 @@ before_script:
 language: node_js
 node_js:
   - "0.10"
+  - '0.12'
+  - iojs
+sudo: false
+cache:
+  directories:
+  - node_modules


### PR DESCRIPTION
In this patch we want to test node 0.12 and also make sure travis test cache `node_modules` for faster test result when we open PR.