### PR TITLE
Remove dependency on messina, Closes #368

### DIFF
--- a/app/http/server.js
+++ b/app/http/server.js
@@ -35,9 +35,7 @@ module.exports = function (env) {
       new nunjucks.FileSystemLoader(path.resolve(__dirname, "../../bower_components"))
     ], {
       autoescape: true
-    }),
-    messina,
-    logger;
+    });
 
   var webmakerAuth = new WebmakerAuth({
     loginURL: env.get("APP_HOSTNAME"),
@@ -60,12 +58,7 @@ module.exports = function (env) {
 
     http.disable("x-powered-by");
 
-    if (!!env.get("ENABLE_GELF_LOGS")) {
-      messina = require("messina");
-      logger = messina("login.webmaker.org-" + env.get("NODE_ENV") || "development");
-      logger.init();
-      http.use(logger.middleware());
-    } else if (!env.get("DISABLE_HTTP_LOGGING")) {
+    if (!env.get("DISABLE_HTTP_LOGGING")) {
       http.use(express.logger());
     }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "helmet": "0.1.2",
     "less": "1.7.5",
     "less-middleware": "0.1.15",
-    "messina": "0.1.1",
     "moment": "2.8.2",
     "mysql": "2.0.1",
     "newrelic": "^1.21.1",


### PR DESCRIPTION
Messina is a very old dependency that hasn't been updated in years. It was built in-house by members of the production team several years ago. It's heavily broken on versions of Node 4.0 and above. This dependency doesn't reside on the Mozilla organization, so we have to drop it entirely.

This dependency causes the command ```npm install``` to fail when using Node 4.0 and above due to its dependence on ```dtrace-provider@0.2.8``` which severely breaks on newer versions of Node. The Travis CI build never failed because the node_modules directory was cached, so even after the upgrade to Node 4.0 this issue was never identified as a result of pre-built binaries being cached.

