### PR TITLE
Replace bcrypt library with bcrypt.js, Closes #386

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,3 @@ addons:
     packages:
     - gcc-4.8
     - g++-4.8
-cache:
-  directories:
-  - node_modules

--- a/app/db/models/index.js
+++ b/app/db/models/index.js
@@ -4,7 +4,7 @@ var crypto = require("crypto");
 var proquint = require("proquint");
 var hat = require("hat");
 var hatchet = require("hatchet");
-var bcrypt = require("bcrypt");
+var bcrypt = require("bcryptjs");
 var url = require("url");
 
 module.exports = function (sequelize, env, newrelic) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "MD5": "1.0.3",
     "async": "0.2.9",
     "badword": "0.0.1",
-    "bcrypt": "0.8.7",
+    "bcryptjs": "2.4.3",
     "bluebird": "2.3.2",
     "bower": "1.3.8",
     "browserid-verify": "0.1.2",


### PR DESCRIPTION
I reviewed the method structure for our current usage of bcrypt and cross-checked it with the method structures for bcrypt.js and it's basically a drop and replace solution. If someone could review this and ensure everything is functioning properly, that'd be great.

I'm filing a separate PR to remove the redundant New Relic references, I wanted to keep this PR as simple as possible and only include the changes relevant for it to function properly.